### PR TITLE
Add support for uploading TV show seasons without numbered seasons

### DIFF
--- a/plex-title-cards.py
+++ b/plex-title-cards.py
@@ -40,11 +40,12 @@ def upload_show(tvdb_id, show_data, library):
 
     # Assume if there are no numbered seasons that the provided season is the first season
     seasons_data = show_data.get('seasons')
-    if sum(isinstance(key, int) for key in seasons_data.keys()) == 0:
-        seasons_data[1] = seasons_data
+    if seasons_data is not None:
+        if sum(isinstance(key, int) for key in seasons_data.keys()) == 0:
+            seasons_data[1] = seasons_data
 
-    for season_number, season_data in seasons_data.items():
-        upload_season(show, season_number, season_data)
+        for season_number, season_data in seasons_data.items():
+            upload_season(show, season_number, season_data)
 
 def upload_season(show, season_number, season_data):
     try:


### PR DESCRIPTION
Fixed this error that was displayed after adding a show with blank seasons attribute.

''' 
Traceback (most recent call last):
  File "path-to-dir\plex-mediUX-title-cards\plex-title-cards.py", line 97, in <module>
    upload_posters(args.file, config_data['plex_url'], config_data['token'])
  File "path-to-dir\Documents\plex-mediUX-title-cards\plex-title-cards.py", line 23, in upload_posters
    upload_show(id, data, library)
  File "path-to-dir\Documents\plex-mediUX-title-cards\plex-title-cards.py", line 43, in upload_show
    if sum(isinstance(key, int) for key in seasons_data.keys()) == 0:
,,,